### PR TITLE
Initialize Next.js static FinOps site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,7 +15,7 @@ jobs:
         with: { node-version: '20' }
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build && pnpm export
+      - run: pnpm build
       - uses: actions/upload-pages-artifact@v3
         with: { path: 'out' }
   deploy:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# finops-site
-FinOps Resources and Consulting
+# FinOps Hub (GitHub Pages / Next.js Static Export)
+
+A hybrid **educational + consulting** FinOps website. Built with **Next.js (App Router) + MDX + Tailwind** and deployed free on **GitHub Pages**.
+
+## Quickstart
+
+1. **Use this repo**: copy files into a new GitHub repo, e.g., `finops-site`.
+2. **Install**
+   ```bash
+   pnpm i
+   pnpm dev
+   ```
+3. **Set your project page**
+   - In `next.config.ts`, leave `isProjectPage = true` (so basePath = `/finops-site`).
+   - If you deploy to `username.github.io` root, set `isProjectPage = false`.
+4. **Deploy**: push to `main`. GitHub Action builds and publishes to Pages automatically.
+
+## Content model
+- Educational pages live under `app/learn/.../page.mdx`.
+- Services/case-studies are MDX pages too.
+- Add more pages by copying an existing folder with `page.mdx`.
+
+## Forms & Search
+- Contact form uses Formspree (replace `your-id`).
+- For search, add Pagefind/Lunr later (client-only).
+
+## SEO
+- Edit `public/sitemap.xml` and `public/robots.txt` with your GitHub Pages URL.
+- `next-seo` is pre-wired for basics.
+
+## Notes for GitHub Pages
+- `output: 'export'` and `images.unoptimized: true` are set.
+- `trailingSlash: true` avoids deep-link 404s.
+
+## Customize
+- Colors in `tailwind.config.ts` (`brand`).
+- Logo/OG image in `public/`.

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import CTA from '../components/CTA'
+import { Metric } from '../components/Metric'
+
+export default function HomePage() {
+  return (
+    <div className="space-y-10">
+      <section className="text-center">
+        <h1 className="text-4xl font-bold">FinOps: Learn, Apply, Optimize</h1>
+        <p className="mx-auto mt-3 max-w-2xl text-slate-600 dark:text-slate-300">
+          A hybrid hub for education and consulting on Cloud Financial Operations.
+          Guides, templates, and workshops to turn cloud cost chaos into clarity.
+        </p>
+        <div className="mt-6 flex justify-center gap-4">
+          <Link href="/learn/finops-principles/" className="rounded-lg bg-brand px-5 py-2 text-white">Start Learning</Link>
+          <Link href="/services/advisory/" className="rounded-lg border px-5 py-2">See Services</Link>
+        </div>
+      </section>
+
+      <section className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <Metric label="Avg. Cost Reduction" value="15–40%" />
+        <Metric label="Workshops Delivered" value="120+" />
+        <Metric label="Clouds Covered" value="AWS · Azure · GCP" />
+        <Metric label="Practitioner Guides" value="25+" />
+      </section>
+
+      <CTA>Want a tailored 2‑week FinOps accelerator for your org?</CTA>
+    </div>
+  )
+}

--- a/app/case-studies/saas-40-cost-reduction/page.mdx
+++ b/app/case-studies/saas-40-cost-reduction/page.mdx
@@ -1,0 +1,16 @@
+import Prose from '../../components/Prose'
+
+<Prose>
+
+# SaaS: 40% Cost Reduction in 8 Weeks
+
+**Problem:** Rapid growth led to 35% cost overrun vs budget.
+
+**Intervention:** Cost allocation → rightsizing → SP/RI portfolio → schedules.
+
+**Results:**
+- 40% monthly cost reduction
+- Zero SLO violations
+- Unit cost ↓ 28%
+
+</Prose>

--- a/app/components/CTA.tsx
+++ b/app/components/CTA.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function CTA({ href = '/contact/', children = 'Book a Workshop' }: { href?: string; children?: React.ReactNode }) {
+  return (
+    <div className="my-8 rounded-xl border border-slate-200/30 bg-slate-50 p-6 dark:bg-slate-900">
+      <div className="flex items-center justify-between gap-6">
+        <div className="text-base">{children}</div>
+        <Link href={href} className="rounded-lg bg-brand px-4 py-2 text-white hover:bg-brand-dark">Get in touch</Link>
+      </div>
+    </div>
+  )
+}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,0 +1,9 @@
+export function Footer() {
+  return (
+    <footer className="mt-16 border-t border-slate-200/20 py-8 text-center text-sm text-slate-500">
+      <div className="mx-auto max-w-5xl px-6">
+        © {new Date().getFullYear()} FinOps Hub · Built with Next.js · Hosted on GitHub Pages
+      </div>
+    </footer>
+  )
+}

--- a/app/components/Metric.tsx
+++ b/app/components/Metric.tsx
@@ -1,0 +1,8 @@
+export function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-slate-200/30 p-4 text-center">
+      <div className="text-2xl font-semibold">{value}</div>
+      <div className="text-xs text-slate-500">{label}</div>
+    </div>
+  )
+}

--- a/app/components/Nav.tsx
+++ b/app/components/Nav.tsx
@@ -1,0 +1,28 @@
+'use client'
+import Link from 'next/link'
+
+const links = [
+  { href: '/', label: 'Home' },
+  { href: '/learn/finops-principles/', label: 'Learn' },
+  { href: '/services/advisory/', label: 'Services' },
+  { href: '/case-studies/saas-40-cost-reduction/', label: 'Case Studies' },
+  { href: '/glossary/', label: 'Glossary' },
+  { href: '/contact/', label: 'Contact' },
+]
+
+export function Nav() {
+  return (
+    <header className="border-b border-slate-200/20 bg-white/70 backdrop-blur dark:bg-slate-950/70">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+        <Link href="/" className="font-semibold">FinOps Hub</Link>
+        <nav className="flex gap-5 text-sm">
+          {links.map(l => (
+            <Link key={l.href} href={l.href} className="hover:text-brand dark:hover:text-brand">
+              {l.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/app/components/Prose.tsx
+++ b/app/components/Prose.tsx
@@ -1,0 +1,3 @@
+export default function Prose({ children }: { children: React.ReactNode }) {
+  return <article className="prose prose-slate max-w-none dark:prose-invert">{children}</article>
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,16 @@
+export default function Contact() {
+  return (
+    <div className="mx-auto max-w-xl">
+      <h1 className="text-2xl font-semibold">Contact</h1>
+      <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+        We typically respond within 1 business day.
+      </p>
+      <form className="mt-6 space-y-4" action="https://formspree.io/f/your-id" method="POST">
+        <input required name="name" placeholder="Your name" className="w-full rounded border px-3 py-2" />
+        <input required type="email" name="email" placeholder="you@example.com" className="w-full rounded border px-3 py-2" />
+        <textarea required name="message" placeholder="How can we help?" className="h-32 w-full rounded border px-3 py-2"></textarea>
+        <button className="rounded-lg bg-brand px-4 py-2 text-white">Send</button>
+      </form>
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root { color-scheme: light dark; }
+html { scroll-behavior: smooth; }
+.prose h2 { scroll-margin-top: 6rem; }

--- a/app/glossary/page.tsx
+++ b/app/glossary/page.tsx
@@ -1,0 +1,21 @@
+const terms = [
+  { term: 'Showback', def: 'Reporting costs back to teams without charge.' },
+  { term: 'Chargeback', def: 'Charging teams for their usage.' },
+  { term: 'Savings Plan / RI', def: 'Commitment-based discounts for steady usage.' },
+]
+
+export default function Glossary() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold">Glossary</h1>
+      <ul className="mt-4 space-y-3">
+        {terms.map(t => (
+          <li key={t.term} className="rounded-lg border p-4">
+            <div className="font-medium">{t.term}</div>
+            <div className="text-sm text-slate-600 dark:text-slate-300">{t.def}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,28 @@
+import './globals.css'
+import type { Metadata } from 'next'
+import { Nav } from './components/Nav'
+import { Footer } from './components/Footer'
+import { DefaultSeo } from 'next-seo'
+
+export const metadata: Metadata = {
+  title: 'FinOps Hub',
+  description: 'Education and consulting for Cloud Financial Operations',
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+        {/* Basic SEO */}
+        {/* @ts-expect-error Server Component */}
+        <DefaultSeo
+          titleTemplate="%s | FinOps Hub"
+          openGraph={{ type: 'website', site_name: 'FinOps Hub' }}
+        />
+        <Nav />
+        <main className="mx-auto max-w-5xl px-6 py-10">{children}</main>
+        <Footer />
+      </body>
+    </html>
+  )
+}

--- a/app/learn/finops-principles/page.mdx
+++ b/app/learn/finops-principles/page.mdx
@@ -1,0 +1,23 @@
+import Prose from '../../components/Prose'
+import CTA from '../../components/CTA'
+
+<Prose>
+
+# FinOps Principles
+
+**FinOps** is the practice of bringing **financial accountability** to the variable spend model of cloud.
+
+## Core Principles
+- **Collaboration** between engineering, finance, and business
+- **Ownership** of spend by teams
+- **Timely, granular data** to drive decisions
+- **Iterative optimization** aligned to performance and reliability
+
+## Outcomes
+- Allocate costs fairly (showback/chargeback)
+- Improve unit economics (cost per customer/request/GB)
+- Align architecture to price-performance
+
+<CTA />
+
+</Prose>

--- a/app/learn/lifecycle-inform-optimize-operate/page.mdx
+++ b/app/learn/lifecycle-inform-optimize-operate/page.mdx
@@ -1,0 +1,11 @@
+import Prose from '../../components/Prose'
+
+<Prose>
+
+# FinOps Lifecycle: Inform → Optimize → Operate
+
+1. **Inform:** Visibility, allocation, forecasting
+2. **Optimize:** Rightsizing, RI/SP, autoscaling, waste elimination
+3. **Operate:** Guardrails, budgets, SLO-aware cost management
+
+</Prose>

--- a/app/learn/pricing-models/page.mdx
+++ b/app/learn/pricing-models/page.mdx
@@ -1,0 +1,11 @@
+import Prose from '../../components/Prose'
+
+<Prose>
+
+# Cloud Pricing Models
+
+- **On-demand**: flexibility, higher rate
+- **Reserved/Savings Plans**: commit for discounts
+- **Spot/Preemptible**: deep savings with interruption risk
+
+</Prose>

--- a/app/learn/rightsizing/page.mdx
+++ b/app/learn/rightsizing/page.mdx
@@ -1,0 +1,11 @@
+import Prose from '../../components/Prose'
+
+<Prose>
+
+# Rightsizing
+
+- Identify idle/over-provisioned resources
+- Use autoscaling and schedules
+- Validate against SLOs/SLIs to preserve reliability
+
+</Prose>

--- a/app/services/advisory/page.mdx
+++ b/app/services/advisory/page.mdx
@@ -1,0 +1,23 @@
+import Prose from '../../components/Prose'
+import CTA from '../../components/CTA'
+
+<Prose>
+
+# Advisory & Implementation
+
+**Who it's for:** CTOs, Finance Leaders, Platform/DevEx, SRE
+
+**Outcomes:**
+- 15–40% cost reduction within 90 days
+- Guardrails that preserve SLOs
+- FinOps operating model & dashboards
+
+**Approach:** Assess → Model → Implement → Operate
+
+**Deliverables:**
+- Cost allocation maps, RI/SP strategy, policy packs
+- Dashboards, runbooks, training
+
+<CTA />
+
+</Prose>

--- a/app/services/training-workshops/page.mdx
+++ b/app/services/training-workshops/page.mdx
@@ -1,0 +1,11 @@
+import Prose from '../../components/Prose'
+
+<Prose>
+
+# Training & Workshops
+
+- FinOps foundations (half‑day)
+- RI/SP mastery (2 hours)
+- Kubernetes cost control (half‑day)
+
+</Prose>

--- a/app/tools/cost-calculator/page.tsx
+++ b/app/tools/cost-calculator/page.tsx
@@ -1,0 +1,42 @@
+'use client'
+import { useState } from 'react'
+
+export default function CostCalculator() {
+  const [accounts, setAccounts] = useState(3)
+  const [regions, setRegions] = useState(2)
+  const [monthlySpend, setMonthlySpend] = useState(10000)
+  const [riCoverage, setRiCoverage] = useState(30) // %
+
+  const optimized = monthlySpend * (1 - Math.min(riCoverage, 80) / 100 * 0.5)
+  const est = optimized * (1 - 0.05 * Math.log(accounts + regions))
+
+  return (
+    <div className="max-w-xl space-y-6">
+      <h1 className="text-2xl font-semibold">Cost Calculator (Simple)</h1>
+      <div className="space-y-3">
+        <label className="block text-sm">Monthly Cloud Spend (₹ or $)</label>
+        <input type="number" value={monthlySpend} onChange={e=>setMonthlySpend(+e.target.value)} className="w-full rounded border px-3 py-2" />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm">Accounts/Projects</label>
+          <input type="number" value={accounts} onChange={e=>setAccounts(+e.target.value)} className="w-full rounded border px-3 py-2" />
+        </div>
+        <div>
+          <label className="block text-sm">Regions</label>
+          <input type="number" value={regions} onChange={e=>setRegions(+e.target.value)} className="w-full rounded border px-3 py-2" />
+        </div>
+      </div>
+      <div>
+        <label className="block text-sm">RI/SP Coverage (%)</label>
+        <input type="range" min={0} max={80} value={riCoverage} onChange={e=>setRiCoverage(+e.target.value)} className="w-full" />
+        <div className="text-sm text-slate-500">{riCoverage}%</div>
+      </div>
+
+      <div className="rounded-xl border p-4">
+        <div className="text-sm text-slate-500">Estimated optimized monthly cost</div>
+        <div className="text-2xl font-semibold">{est.toLocaleString()}</div>
+      </div>
+    </div>
+  )
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,0 +1,14 @@
+'use client'
+import * as React from 'react'
+
+export function useMDXComponents(components: any) {
+  return {
+    h2: (props: any) => <h2 className="mt-10 mb-4 text-2xl font-semibold" {...props} />,
+    h3: (props: any) => <h3 className="mt-8 mb-3 text-xl font-semibold" {...props} />,
+    p: (props: any) => <p className="my-4 leading-7" {...props} />,
+    ul: (props: any) => <ul className="my-4 list-disc pl-6" {...props} />,
+    ol: (props: any) => <ol className="my-4 list-decimal pl-6" {...props} />,
+    code: (props: any) => <code className="rounded bg-black/10 px-1 py-0.5" {...props} />,
+    ...components,
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,21 @@
+import createMDX from '@next/mdx';
+
+const isProjectPage = true; // set false if deploying to username.github.io root
+const base = isProjectPage ? '/finops-site' : '';
+
+const withMDX = createMDX({
+  extension: /\.(md|mdx)$/,
+});
+
+/** @type {import('next').NextConfig} */
+const nextConfig = withMDX({
+  output: 'export',
+  pageExtensions: ['ts', 'tsx', 'md', 'mdx'],
+  images: { unoptimized: true },
+  basePath: base || undefined,
+  assetPrefix: base ? `${base}/` : undefined,
+  trailingSlash: true,
+  experimental: { mdxRs: true }
+});
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "finops-site",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "next start",
+    "lint": "echo 'no lint configured'",
+    "preview": "npx serve -s out"
+  },
+  "dependencies": {
+    "next": "^14.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "next-seo": "^6.5.0"
+  },
+  "devDependencies": {
+    "@next/mdx": "^14.2.5",
+    "@types/node": "^20.12.12",
+    "@types/react": "^18.2.79",
+    "@types/react-dom": "^18.2.25",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.10",
+    "typescript": "^5.5.4"
+  },
+  "packageManager": "pnpm@9.6.0"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,43 @@
+lockfileVersion: '9.6'
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+dependencies:
+  next:
+    specifier: ^14.2.5
+    version: 14.2.5
+  react:
+    specifier: ^18.3.1
+    version: 18.3.1
+  react-dom:
+    specifier: ^18.3.1
+    version: 18.3.1
+  next-seo:
+    specifier: ^6.5.0
+    version: 6.5.0
+devDependencies:
+  '@next/mdx':
+    specifier: ^14.2.5
+    version: 14.2.5
+  '@types/node':
+    specifier: ^20.12.12
+    version: 20.12.12
+  '@types/react':
+    specifier: ^18.2.79
+    version: 18.2.79
+  '@types/react-dom':
+    specifier: ^18.2.25
+    version: 18.2.25
+  autoprefixer:
+    specifier: ^10.4.19
+    version: 10.4.19
+  postcss:
+    specifier: ^8.4.38
+    version: 8.4.38
+  tailwindcss:
+    specifier: ^3.4.10
+    version: 3.4.10
+  typescript:
+    specifier: ^5.5.4
+    version: 5.5.4
+packages: {}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://<your-username>.github.io/finops-site/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://<your-username>.github.io/finops-site/</loc></url>
+  <url><loc>https://<your-username>.github.io/finops-site/learn/finops-principles/</loc></url>
+  <url><loc>https://<your-username>.github.io/finops-site/services/advisory/</loc></url>
+  <url><loc>https://<your-username>.github.io/finops-site/case-studies/saas-40-cost-reduction/</loc></url>
+  <url><loc>https://<your-username>.github.io/finops-site/glossary/</loc></url>
+  <url><loc>https://<your-username>.github.io/finops-site/contact/</loc></url>
+</urlset>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,19 @@
+import type { Config } from 'tailwindcss'
+
+export default {
+  content: [
+    './app/**/*.{ts,tsx,mdx}',
+    './mdx-components.tsx'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: '#0ea5e9',
+          dark: '#0284c7'
+        }
+      }
+    }
+  },
+  plugins: []
+} satisfies Config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "es2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["app", "mdx-components.tsx", "next-env.d.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js App Router project with MDX and Tailwind for FinOps Hub
- add reusable UI components, educational pages and tools
- configure GitHub Pages workflow for static export deployment
- remove binary image assets to satisfy platform restrictions

## Testing
- `pnpm install --frozen-lockfile` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm build` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b16e0fbb388325aca5a9e4ebbbb9e1