### PR TITLE
chore: add @next/mdx as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "next": "^14.2.5",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@next/mdx": "^14.2.5"
   },
   "devDependencies": {
-    "@next/mdx": "^14.2.5",
     "@types/node": "^20.12.12",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@next/mdx':
+        specifier: ^14.2.5
+        version: 14.2.32
       next:
         specifier: ^14.2.5
         version: 14.2.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -18,9 +21,6 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
-      '@next/mdx':
-        specifier: ^14.2.5
-        version: 14.2.32
       '@types/node':
         specifier: ^20.12.12
         version: 20.19.11


### PR DESCRIPTION
## Summary
- move `@next/mdx` from devDependencies to dependencies to ensure it's installed in production

## Testing
- `pnpm test` *(fails: Missing script: test)*
- `pnpm build`
- `pnpm install` *(fails: No authorization header was set for the request)*
- `docker build -t finops-site .` *(fails: command not found)*
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_68b19ef1b43883259c2df8e579097117