### PR TITLE
Style basic pages with Tailwind typography

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,10 +1,10 @@
+import Prose from '@/components/Prose'
+
 export default function AboutPage() {
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-semibold">About</h1>
-      <p className="text-sm text-slate-600 dark:text-slate-300">
-        FinOps Hub provides guidance and services to help organizations manage cloud spend.
-      </p>
-    </div>
+    <Prose>
+      <h1>About</h1>
+      <p>FinOps Hub provides guidance and services to help organizations manage cloud spend.</p>
+    </Prose>
   )
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,12 +1,13 @@
 import LeadForm from '@/components/LeadForm'
+import Prose from '@/components/Prose'
 
 export default function Contact() {
   return (
     <div className="mx-auto max-w-xl">
-      <h1 className="text-2xl font-semibold">Contact</h1>
-      <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
-        We typically respond within 1 business day.
-      </p>
+      <Prose>
+        <h1>Contact</h1>
+        <p>We typically respond within 1 business day.</p>
+      </Prose>
       <LeadForm />
     </div>
   )

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -1,14 +1,15 @@
 import Link from 'next/link'
+import Prose from '@/components/Prose'
 
 export default function ResourcesPage() {
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-semibold">Resources</h1>
-      <ul className="list-disc pl-6 text-sm">
+    <Prose>
+      <h1>Resources</h1>
+      <ul>
         <li><Link href="/resources/blog/">Blog</Link></li>
         <li><Link href="/resources/templates/">Templates</Link></li>
         <li><Link href="/resources/books-courses/">Books & Courses</Link></li>
       </ul>
-    </div>
+    </Prose>
   )
 }

--- a/components/LeadForm.tsx
+++ b/components/LeadForm.tsx
@@ -3,10 +3,26 @@
 export default function LeadForm() {
   return (
     <form className="mt-6 space-y-4" action="https://formspree.io/f/your-id" method="POST">
-      <input required name="name" placeholder="Your name" className="w-full rounded border px-3 py-2" />
-      <input required type="email" name="email" placeholder="you@example.com" className="w-full rounded border px-3 py-2" />
-      <textarea required name="message" placeholder="How can we help?" className="h-32 w-full rounded border px-3 py-2"></textarea>
-      <button className="rounded-lg bg-brand px-4 py-2 text-white">Send</button>
+      <input
+        required
+        name="name"
+        placeholder="Your name"
+        className="w-full rounded-md border-slate-300 bg-white px-3 py-2 shadow-sm focus:border-brand focus:ring-brand dark:border-slate-700 dark:bg-slate-900"
+      />
+      <input
+        required
+        type="email"
+        name="email"
+        placeholder="you@example.com"
+        className="w-full rounded-md border-slate-300 bg-white px-3 py-2 shadow-sm focus:border-brand focus:ring-brand dark:border-slate-700 dark:bg-slate-900"
+      />
+      <textarea
+        required
+        name="message"
+        placeholder="How can we help?"
+        className="h-32 w-full rounded-md border-slate-300 bg-white px-3 py-2 shadow-sm focus:border-brand focus:ring-brand dark:border-slate-700 dark:bg-slate-900"
+      />
+      <button className="rounded-lg bg-brand px-4 py-2 text-white hover:bg-brand-dark focus:outline-none focus:ring-2 focus:ring-brand">Send</button>
     </form>
   )
 }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "lint": "echo 'no lint configured'"
   },
   "dependencies": {
+    "@next/mdx": "^14.2.5",
     "next": "^14.2.5",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "@next/mdx": "^14.2.5"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@tailwindcss/forms": "^0.5.10",
+    "@tailwindcss/typography": "^0.5.16",
     "@types/node": "^20.12.12",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,12 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@tailwindcss/forms':
+        specifier: ^0.5.10
+        version: 0.5.10(tailwindcss@3.4.17)
+      '@tailwindcss/typography':
+        specifier: ^0.5.16
+        version: 0.5.16(tailwindcss@3.4.17)
       '@types/node':
         specifier: ^20.12.12
         version: 20.19.11
@@ -155,6 +161,16 @@ packages:
 
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
+
+  '@tailwindcss/forms@0.5.10':
+    resolution: {integrity: sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1'
+
+  '@tailwindcss/typography@0.5.16':
+    resolution: {integrity: sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
   '@types/node@20.19.11':
     resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
@@ -374,6 +390,15 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  lodash.castarray@4.4.0:
+    resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -388,6 +413,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mini-svg-data-uri@1.4.4:
+    resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
+    hasBin: true
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -500,6 +529,10 @@ packages:
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -751,6 +784,19 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.8.1
 
+  '@tailwindcss/forms@0.5.10(tailwindcss@3.4.17)':
+    dependencies:
+      mini-svg-data-uri: 1.4.4
+      tailwindcss: 3.4.17
+
+  '@tailwindcss/typography@0.5.16(tailwindcss@3.4.17)':
+    dependencies:
+      lodash.castarray: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.17
+
   '@types/node@20.19.11':
     dependencies:
       undici-types: 6.21.0
@@ -953,6 +999,12 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lodash.castarray@4.4.0: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.merge@4.6.2: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -965,6 +1017,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mini-svg-data-uri@1.4.4: {}
 
   minimatch@9.0.5:
     dependencies:
@@ -1057,6 +1111,11 @@ snapshots:
     dependencies:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@6.1.2:
     dependencies:

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,6 @@
 import type { Config } from 'tailwindcss'
+import forms from '@tailwindcss/forms'
+import typography from '@tailwindcss/typography'
 
 export default {
   content: [
@@ -15,5 +17,5 @@ export default {
       }
     }
   },
-  plugins: []
+  plugins: [forms, typography]
 } satisfies Config


### PR DESCRIPTION
## Summary
- add Tailwind typography and forms plugins
- style About, Resources, and Contact pages with `Prose`
- refine contact form inputs and button styling

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b1a10071188325b5496c7d79c0af0a