### PR TITLE
feat: replicate dashboard styling

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,30 +1,127 @@
-import Link from 'next/link'
-import CTA from '@/components/CTA'
-import { Metric } from '@/components/Metric'
-
 export default function HomePage() {
   return (
-    <div className="space-y-10">
-      <section className="text-center">
-        <h1 className="text-4xl font-bold">FinOps: Learn, Apply, Optimize</h1>
-        <p className="mx-auto mt-3 max-w-2xl text-slate-600 dark:text-slate-300">
-          A hybrid hub for education and consulting on Cloud Financial Operations.
-          Guides, templates, and workshops to turn cloud cost chaos into clarity.
+    <>
+      {/* Overview Section */}
+      <section id="overview" className="content-section">
+        <h2 className="text-4xl font-bold text-slate-900 mb-4">
+          FinOps: A Guide to Cloud Financial Management
+        </h2>
+        <p className="text-lg text-slate-600 mb-8 max-w-4xl">
+          FinOps is a cultural practice that brings financial accountability to the variable spend model of the cloud. It enables organizations to get maximum business value by helping engineering, finance, and business teams to collaborate on data-driven spending decisions.
         </p>
-        <div className="mt-6 flex justify-center gap-4">
-          <Link href="/learn/finops-principles/" className="rounded-lg bg-brand px-5 py-2 text-white">Start Learning</Link>
-          <Link href="/services/advisory/" className="rounded-lg border px-5 py-2">See Services</Link>
+      </section>
+
+      {/* Principles Section */}
+      <section id="principles" className="content-section">
+        <h2 className="text-3xl font-bold text-slate-900 mb-6">The Three Phases of FinOps</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className="bg-white p-6 rounded-lg shadow-md hover:shadow-xl hover:-translate-y-1 transition-all">
+            <div className="flex items-center space-x-4 mb-2">
+              <span className="text-2xl font-bold text-sky-600">1.</span>
+              <h3 className="text-xl font-bold text-slate-900">Inform</h3>
+            </div>
+            <p className="text-slate-600">
+              Making cloud cost data visible and understandable to all stakeholders. This involves creating a single source of truth for cloud spend and business drivers.
+            </p>
+          </div>
+          <div className="bg-white p-6 rounded-lg shadow-md hover:shadow-xl hover:-translate-y-1 transition-all">
+            <div className="flex items-center space-x-4 mb-2">
+              <span className="text-2xl font-bold text-sky-600">2.</span>
+              <h3 className="text-xl font-bold text-slate-900">Optimize</h3>
+            </div>
+            <p className="text-slate-600">
+              Taking action to reduce cloud costs through rightsizing, deleting unused resources, or using committed-use discounts and reserved instances.
+            </p>
+          </div>
+          <div className="bg-white p-6 rounded-lg shadow-md hover:shadow-xl hover:-translate-y-1 transition-all">
+            <div className="flex items-center space-x-4 mb-2">
+              <span className="text-2xl font-bold text-sky-600">3.</span>
+              <h3 className="text-xl font-bold text-slate-900">Operate</h3>
+            </div>
+            <p className="text-slate-600">
+              Implementing continuous, automated processes to manage and forecast cloud spend. This embeds financial accountability into daily operations.
+            </p>
+          </div>
         </div>
       </section>
 
-      <section className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-        <Metric label="Avg. Cost Reduction" value="15–40%" />
-        <Metric label="Workshops Delivered" value="120+" />
-        <Metric label="Clouds Covered" value="AWS · Azure · GCP" />
-        <Metric label="Practitioner Guides" value="25+" />
+      {/* Metrics Section */}
+      <section id="metrics" className="content-section">
+        <h2 className="text-3xl font-bold text-slate-900 mb-6">Key FinOps Metrics</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="bg-white p-6 rounded-lg shadow-md">
+            <h3 className="text-xl font-bold text-slate-900 mb-2">Unit Cost</h3>
+            <p className="text-slate-600 mb-4">The cost of a single business unit, like cost per user or cost per transaction. This metric ties cloud spend directly to business value.</p>
+            <div className="w-full h-4 bg-slate-200 rounded-full overflow-hidden">
+              <div className="h-full bg-sky-600" style={{ width: '75%' }}></div>
+            </div>
+            <p className="text-right text-sm text-slate-500 mt-1">75% of target unit cost</p>
+          </div>
+          <div className="bg-white p-6 rounded-lg shadow-md">
+            <h3 className="text-xl font-bold text-slate-900 mb-2">Savings Rate</h3>
+            <p className="text-slate-600 mb-4">The percentage of total cloud spend that was saved through optimization efforts. A key indicator of FinOps program success.</p>
+            <div className="w-full h-4 bg-slate-200 rounded-full overflow-hidden">
+              <div className="h-full bg-sky-600" style={{ width: '25%' }}></div>
+            </div>
+            <p className="text-right text-sm text-slate-500 mt-1">25% month-over-month savings</p>
+          </div>
+          <div className="bg-white p-6 rounded-lg shadow-md">
+            <h3 className="text-xl font-bold text-slate-900 mb-2">Reserved Instance Coverage</h3>
+            <p className="text-slate-600 mb-4">The percentage of eligible compute usage that is covered by reserved instances or savings plans. A higher percentage indicates better long-term planning.</p>
+            <div className="w-full h-4 bg-slate-200 rounded-full overflow-hidden">
+              <div className="h-full bg-sky-600" style={{ width: '85%' }}></div>
+            </div>
+            <p className="text-right text-sm text-slate-500 mt-1">85% coverage</p>
+          </div>
+          <div className="bg-white p-6 rounded-lg shadow-md">
+            <h3 className="text-xl font-bold text-slate-900 mb-2">Cloud Spend Variance</h3>
+            <p className="text-slate-600 mb-4">The difference between budgeted and actual cloud spend. Low variance indicates accurate forecasting and good cost control.</p>
+            <div className="w-full h-4 bg-slate-200 rounded-full overflow-hidden">
+              <div className="h-full bg-red-500" style={{ width: '45%' }}></div>
+            </div>
+            <p className="text-right text-sm text-red-500 mt-1">45% over budget</p>
+          </div>
+        </div>
       </section>
 
-      <CTA>Want a tailored 2‑week FinOps accelerator for your org?</CTA>
-    </div>
+      {/* Dashboard Section */}
+      <section id="dashboard" className="content-section">
+        <h2 className="text-3xl font-bold text-slate-900 mb-6">Cloud Spend Dashboard</h2>
+        <div className="bg-white p-6 rounded-lg shadow-md">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            <div className="p-6 bg-slate-100 rounded-lg">
+              <p className="text-sm font-semibold text-slate-500">Total Monthly Spend</p>
+              <p className="text-4xl font-bold text-slate-900 mt-2">$1,245,678</p>
+              <p className="text-sm text-red-500 mt-2">↑ 5% from last month</p>
+            </div>
+            <div className="p-6 bg-slate-100 rounded-lg">
+              <p className="text-sm font-semibold text-slate-500 mb-4">Top 5 Services by Cost</p>
+              <ul className="space-y-2">
+                <li className="flex justify-between items-center text-slate-700">
+                  <span>Compute Engine</span>
+                  <span className="font-semibold">$520,300</span>
+                </li>
+                <li className="flex justify-between items-center text-slate-700">
+                  <span>Cloud Storage</span>
+                  <span className="font-semibold">$315,800</span>
+                </li>
+                <li className="flex justify-between items-center text-slate-700">
+                  <span>Kubernetes Engine</span>
+                  <span className="font-semibold">$210,000</span>
+                </li>
+                <li className="flex justify-between items-center text-slate-700">
+                  <span>BigQuery</span>
+                  <span className="font-semibold">$120,500</span>
+                </li>
+                <li className="flex justify-between items-center text-slate-700">
+                  <span>Pub/Sub</span>
+                  <span className="font-semibold">$79,078</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,3 +5,18 @@
 :root { color-scheme: light dark; }
 html { scroll-behavior: smooth; }
 .prose h2 { scroll-margin-top: 6rem; }
+
+.nav-link {
+  @apply relative transition-all duration-200;
+}
+.nav-link::after {
+  content: '';
+  @apply absolute left-1/2 -bottom-[5px] h-[3px] w-0 -translate-x-1/2 bg-green-500 transition-all duration-300;
+}
+.nav-link:hover::after {
+  @apply w-full;
+}
+
+.content-section {
+  @apply min-h-[calc(100vh-80px)] pt-20;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import type { Metadata } from 'next'
+import { Inter } from 'next/font/google'
 import { Nav } from '@/components/Nav'
 import { Footer } from '@/components/Footer'
 
@@ -12,13 +13,14 @@ export const metadata: Metadata = {
   },
 }
 
+const inter = Inter({ subsets: ['latin'], display: 'swap' })
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100">
-        {/* Basic SEO handled via Next.js metadata */}
+      <body className={`${inter.className} min-h-screen bg-slate-50 text-slate-800`}>
         <Nav />
-        <main className="mx-auto max-w-5xl px-6 py-10">{children}</main>
+        <main className="container mx-auto p-4 sm:p-6 md:p-10 mt-16">{children}</main>
         <Footer />
       </body>
     </html>

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,29 +1,57 @@
 'use client'
 import Link from 'next/link'
+import { useState } from 'react'
 
 const links = [
-  { href: '/', label: 'Home' },
-  { href: '/learn/finops-principles/', label: 'Learn' },
-  { href: '/services/advisory/', label: 'Services' },
-  { href: '/case-studies/saas-40-cost-reduction/', label: 'Case Studies' },
-  { href: '/glossary/', label: 'Glossary' },
-  { href: '/contact/', label: 'Contact' },
+  { href: '#principles', label: 'Principles' },
+  { href: '#metrics', label: 'Metrics' },
+  { href: '#dashboard', label: 'Dashboard' },
 ]
 
 export function Nav() {
+  const [open, setOpen] = useState(false)
   return (
-    <header className="w-full border-b border-slate-200/20 bg-white/70 backdrop-blur dark:bg-slate-950/70">
-      <div className="mx-auto flex max-w-5xl items-center px-6 py-4">
-        <Link href="/" className="font-semibold">FinOps Hub</Link>
-        <nav className="ml-auto flex space-x-5 text-sm">
-
-          {links.map(l => (
-            <Link key={l.href} href={l.href} className="hover:text-brand dark:hover:text-brand">
-              {l.label}
+    <header className="bg-slate-800 text-slate-100 p-4 fixed top-0 left-0 right-0 z-50 shadow-md">
+      <div className="container mx-auto flex justify-between items-center">
+        <Link href="#overview" className="text-2xl font-bold text-sky-400">
+          FinOps Guide
+        </Link>
+        <nav id="top-nav" className="hidden md:flex space-x-6">
+          {links.map(link => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="nav-link text-lg p-3 rounded-md hover:text-sky-300"
+            >
+              {link.label}
             </Link>
           ))}
         </nav>
+        <button
+          id="mobile-menu-btn"
+          className="md:hidden text-sky-400 text-2xl"
+          onClick={() => setOpen(o => !o)}
+        >
+          ☰
+        </button>
       </div>
+      <nav
+        id="mobile-nav"
+        className={`md:hidden absolute top-full left-0 right-0 bg-slate-800 shadow-md flex flex-col items-center py-4 space-y-2 ${
+          open ? '' : 'hidden'
+        }`}
+      >
+        {links.map(link => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className="nav-link text-lg p-3 rounded-md hover:text-sky-300"
+            onClick={() => setOpen(false)}
+          >
+            {link.label}
+          </Link>
+        ))}
+      </nav>
     </header>
   )
 }


### PR DESCRIPTION
## Summary
- add fixed header with mobile menu and animated nav links
- switch layout to Inter font and spacious container
- build single-page sections for overview, principles, metrics, and dashboard

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b2812b833c8325bbd435c3e5f0f2b3